### PR TITLE
Limit acceleration to prevent skidding, jerky turns and wheelies.

### DIFF
--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -448,10 +448,10 @@ public class DriveSubsystem extends SubsystemBase {
 
         // reduce acceleration independently for each wheel.
         if (Math.abs(leftAccel) > Math.abs(maxAccel)) {
-            leftSpeed = previousLeftSpeed * (Math.signum(leftAccel) * maxAccel) * seconds;
+            leftSpeed = previousLeftSpeed - ((Math.signum(leftAccel) * maxAccel) * seconds);
         }
         if (Math.abs(rightAccel) > Math.abs(maxAccel)) {
-            rightSpeed = previousRightSpeed * (Math.signum(rightAccel) * maxAccel) * seconds;
+            rightSpeed = previousRightSpeed - ((Math.signum(rightAccel) * maxAccel) * seconds);
         }
 
     }


### PR DESCRIPTION
This slows down acceleration SLIGHTLY so that the forces on the robot are a little controlled.  This should have a negligible impact on overall timing of operations and look very smooth instead